### PR TITLE
Open and/or close the infowindow on mouse over/out

### DIFF
--- a/dist/snazzy-info-window.js
+++ b/dist/snazzy-info-window.js
@@ -87,6 +87,8 @@
         placement: 'top',
         pointer: true,
         openOnMarkerClick: true,
+        openOnMarkerMouseOver: false,
+        closeOnMarkerMouseOut: false,
         closeOnMapClick: true,
         closeWhenOthersOpen: false,
         showCloseButton: true,
@@ -226,7 +228,25 @@
                     }
                 }), true);
             }
-
+			
+			// This listener remains active when the info window is closed.
+			if (_this._marker && _this._opts.openOnMarkerMouseOver) {
+				_this.trackListener(google.maps.event.addListener(_this._marker, 'mouseover', function () {
+					if (!_this.getMap()) {
+						_this.open();
+					}
+				}), true);
+			}
+			
+			// This listener remains active when the info window is closed.
+			if (_this._marker && _this._opts.closeOnMarkerMouseOut) {
+				_this.trackListener(google.maps.event.addListener(_this._marker, 'mouseout', function () {
+					if (_this.getMap()) {
+						_this.close();
+					}
+				}), true);
+			}
+			
             // When using a position the default option for the offset is 0
             if (_this._position && !_this._opts.offset) {
                 _this._opts.offset = {


### PR DESCRIPTION
The following changes will allow to open the infowindow on Mouseover event and close it on Mouseout event.

1. "openOnMarkerMouseOver": Determines if the info window will open on marker "mouseover" event. An internal listener is added to the Google Maps "mouseover" event which calls the "open()" method.
- Type: boolean
- Default: false

2. "closeOnMarkerMouseOut": Determines if the info window will close on marker "mouseout" event. An internal listener is added to the Google Maps "mouseout" event which calls the "close()" method.
- Type: boolean
- Default: false