### PR TITLE
Added whitelistedMouseEvent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,17 @@ Determines if the info window will be panned into view when opened.
 - Type: _boolean_
 - Default: `true`
 
+#### whitelistedMouseEvents
+
+An optional list of mouse events whose execution will not be stopped when the event occurs.
+
+- Type: _array_
+- Example:
+
+    ```js
+    whitelistedMouseEvents: ['mousedown', 'mouseup']
+    ```
+
 ### callbacks
 
 All callbacks are optional and can access the info window instance via `this`.

--- a/src/snazzy-info-window.js
+++ b/src/snazzy-info-window.js
@@ -602,11 +602,18 @@ export default class SnazzyInfoWindow extends getGoogleClass() {
         }
 
         // Stop the mouse event propagation
-        const mouseEvents = ['click', 'dblclick', 'rightclick', 'contextmenu',
+        let mouseEvents = ['click', 'dblclick', 'rightclick', 'contextmenu',
             'drag', 'dragend', 'dragstart',
             'mousedown', 'mouseout', 'mouseover', 'mouseup',
             'touchstart', 'touchend', 'touchmove',
             'wheel', 'mousewheel', 'DOMMouseScroll', 'MozMousePixelScroll'];
+        if (this._opts.whitelistedMouseEvents) {
+            const whitelistedEvents = this._opts.whitelistedMouseEvents;
+            mouseEvents = mouseEvents.filter((event) => {
+                return whitelistedEvents.indexOf(event) < 0;
+            });
+        }
+
         mouseEvents.forEach((event) => {
             this.trackListener(google.maps.event.addDomListener(this._html.wrapper,
                 event, (e) => {


### PR DESCRIPTION
### **Whitelisted mouse events**

This change introduces a new option, **whitelistedMouseEvents**, that lets users specify an optional list (_array_) of events whose execution will not be stopped.

The problem, that made this change necessary, was occurring in an ionic application, with snazzy info window template configured **to not display** the close button. 

After opening the first snazzy-info-window it would remain open forever even when _tapping_ on a different area of the map. This was because all the mouse/touch events were being stopped.

Now users can set the proper option (whitelistedMouseEvents) using an array of events, preventing all of them from being stopped.
